### PR TITLE
Fix typespec of known_languages/0, /1

### DIFF
--- a/lib/cldr/language.ex
+++ b/lib/cldr/language.ex
@@ -110,9 +110,10 @@ defmodule Cldr.Language do
             "tiv" => %{standard: "Tiv"}, "aln" => %{standard: "Gheg Albanian"},
             "sh" => %{standard: "Serbo-Croatian"}, "fil" => %{...}, ...}
         """
-        @spec known_languages() :: %{required(styles()) => String.t()} | {:error, term()}
+        @spec known_languages() ::
+                %{String.t() => %{required(styles()) => String.t()}} | {:error, term()}
         @spec known_languages(String.t() | LanguageTag.t()) ::
-                %{required(styles()) => String.t()} | {:error, term()}
+                %{String.t() => %{required(styles()) => String.t()}} | {:error, term()}
         def known_languages(locale \\ get_locale())
 
         def known_languages(%LanguageTag{cldr_locale_name: cldr_locale_name}) do


### PR DESCRIPTION
Fixes dialyzer errors about specs not matching success typing.

Adds the `%{code => style_map}` wrapper map to the spec.