### PR TITLE
Runtime performance

### DIFF
--- a/lib/cldr/language.ex
+++ b/lib/cldr/language.ex
@@ -124,7 +124,7 @@ defmodule Cldr.Language do
           languages = locale_name |> Cldr.Config.get_locale(config) |> Map.get(:languages)
 
           def available_languages(unquote(locale_name)) do
-            Enum.sort(unquote(Map.keys(languages)))
+            unquote(Enum.sort(Map.keys(languages)))
           end
 
           def known_languages(unquote(locale_name)) do


### PR DESCRIPTION
Considering compilation already takes a fair bit of time, this increase that time slightly as a trade-off for improved  performance.

I'm not sure why the definition of `known_languages/1` uses `Macro.escape/1` but `available_languages` did not. I didn't introduce it because it seems to work without but wanted to mention it regardless.