### PR TITLE
fix for Language.known_languages's spec

### DIFF
--- a/lib/cldr/language.ex
+++ b/lib/cldr/language.ex
@@ -110,9 +110,9 @@ defmodule Cldr.Language do
             "tiv" => %{standard: "Tiv"}, "aln" => %{standard: "Gheg Albanian"},
             "sh" => %{standard: "Serbo-Croatian"}, "fil" => %{...}, ...}
         """
-        @spec known_languages() :: %{required(styles()) => String.t()} | {:error, term()}
+        @spec known_languages() :: %{required(String.t()) => %{required(atom) => String.t()}} | {:error, term()}
         @spec known_languages(String.t() | LanguageTag.t()) ::
-                %{required(styles()) => String.t()} | {:error, term()}
+                %{required(String.t()) => %{required(atom) => String.t()}} | {:error, term()}
         def known_languages(locale \\ get_locale())
 
         def known_languages(%LanguageTag{cldr_locale_name: cldr_locale_name}) do


### PR DESCRIPTION
I use [dialyzer](https://hexdocs.pm/dialyzex/Mix.Tasks.Dialyzer.html) in some project. Now I included **cldr_languages** library and I got error (see below).
It looks like Language.known_languages's spec is wrong, take a look on my PR with fix.


```
mix dialyzer --halt-exit-status
...
language.ex:1:invalid_contract

Invalid type specification for function.



Function:

Language.known_languages/0



Success typing:

@spec known_languages() ::

  {:error, {Cldr.UnknownLocaleError, <<_::64, _::size(8)>>}}

  | %{

      <<_::16, _::size(8)>> => %{

        :standard => <<_::16, _::size(8)>>,

        :long => <<_::128>>,

        :short => <<_::16, _::size(8)>>,

        :variant => <<_::40, _::size(8)>>

      }

    }

________________________________________________________________________________

language.ex:1:invalid_contract

Invalid type specification for function.



Function:

Language.known_languages/1



Success typing:

@spec known_languages(

  binary()

  | %Cldr.LanguageTag{

      :cldr_locale_name =>

        binary()

        | %Cldr.LanguageTag{

            :cldr_locale_name =>

              binary() | %Cldr.LanguageTag{:cldr_locale_name => binary() | map(), _ => _},

            _ => _

          },

      _ => _

    }

) ::

  {:error, {Cldr.UnknownLocaleError, <<_::64, _::size(8)>>}}

  | %{

      <<_::16, _::size(8)>> => %{

        :standard => <<_::16, _::size(8)>>,

        :long => <<_::128>>,

        :short => <<_::16, _::size(8)>>,

        :variant => <<_::40, _::size(8)>>

      }

    }
```