### PR TITLE
Change license metadata field to a valid SPDX identifier

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule CldrLanguages.Mixfile do
     [
       files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"],
       maintainers: ["Benjamin Milde"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/LostKobrakai/cldr_languages"}
     ]
   end


### PR DESCRIPTION
Not mandatory, but recommended for hex.pm. https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode

Can be useful for a project like https://github.com/Cantido/hex_licenses